### PR TITLE
fix: restore Node CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,24 +1,22 @@
-            - name: Setup Node.js environment
-  uses: actions/setup-node@v3.9.1
-  with:
-    # Set always-auth in npmrc.
-    always-auth: # optional, default is false
-    # Version Spec of the version to use. Examples: 12.x, 10.15.1, >=10.15.0.
-    node-version: # optional
-    # File containing the version Spec of the version to use.  Examples: .nvmrc, .node-version, .tool-versions.
-    node-version-file: # optional
-    # Target architecture for Node to use. Examples: x86, x64. Will use system architecture by default.
-    architecture: # optional
-    # Set this option if you want the action to check for the latest available version that satisfies the version spec.
-    check-latest: # optional
-    # Optional registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, and set up auth to read in from env.NODE_AUTH_TOKEN.
-    registry-url: # optional
-    # Optional scope for authenticating against scoped registries. Will fall back to the repository owner when using the GitHub Packages registry (https://npm.pkg.github.com/).
-    scope: # optional
-    # Used to pull node distributions from node-versions. Since there's a default, this is typically not supplied by the user. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.
-    token: # optional, default is ${{ github.server_url == 'https://github.com' && github.token || '' }}
-    # Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm.
-    cache: # optional
-    # Used to specify the path to a dependency file: package-lock.json, yarn.lock, etc. Supports wildcards or a list of file names for caching multiple dependencies.
-    cache-dependency-path: # optional
-          
+---
+name: CI
+
+'on':
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npm test


### PR DESCRIPTION
## Summary
- fix malformed GitHub Actions workflow

## Testing
- `yamllint .github/workflows/main.yml`
- `npm test` *(fails: Could not read package.json: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688e640a0de0832ea35eb1e9229b6f30

## Summary by Sourcery

Restore and correct the GitHub Actions CI workflow for Node.js by replacing the malformed YAML with a properly structured main.yml that triggers on push and pull_request to main and runs checkout, Node.js setup, install, and test steps.

Bug Fixes:
- Fix malformed GitHub Actions main.yml by removing improperly indented options and restoring a valid workflow structure

CI:
- Add CI triggers for push and pull_request on main and define a build job that checks out code, sets up Node.js 18 via actions/setup-node@v3, runs npm install, and executes npm test